### PR TITLE
Update API

### DIFF
--- a/nodeman/models.py
+++ b/nodeman/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from cryptography.x509 import load_pem_x509_certificates
-from pydantic import AnyHttpUrl, BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from .db_models import TapirNode
 from .settings import MqttUrl
@@ -41,13 +41,16 @@ class NodeCollection(BaseModel):
 
 
 class NodeConfiguration(BaseModel):
-    name: str = Field(title="Node name")
-    mqtt_broker: MqttUrl = Field(title="MQTT Broker")
-    mqtt_topics: dict[str, str] = Field(title="MQTT Topics", default={})
+    name: str = Field(title="Node name", examples=["node.example.com"])
+    mqtt_broker: MqttUrl = Field(title="MQTT Broker", examples=["mqtts://broker.example.com"])
+    mqtt_topics: dict[str, str] = Field(
+        title="MQTT Topics",
+        default={},
+        examples=[{"edm": "configuration/node.example.com/edm", "pop": "configuration/node.example.com/pop"}],
+    )
     trusted_keys: list[PublicJwk] = Field(title="Trusted keys")
     x509_certificate: str = Field(title="X.509 Client Certificate Bundle")
     x509_ca_certificate: str = Field(title="X.509 CA Certificate Bundle")
-    x509_ca_url: AnyHttpUrl = Field(title="X.509 CA URL")
 
     @field_validator("x509_certificate", "x509_ca_certificate")
     @classmethod

--- a/nodeman/nodes.py
+++ b/nodeman/nodes.py
@@ -140,7 +140,7 @@ def delete_node(
 @router.post(
     "/api/v1/node/{name}/enroll",
     responses={
-        201: {"model": NodeConfiguration},
+        200: {"model": NodeConfiguration},
     },
     tags=["client"],
 )
@@ -203,7 +203,6 @@ async def enroll_node(
         [certificate.public_bytes(serialization.Encoding.PEM).decode() for certificate in ca_response.cert_chain]
     )
     x509_ca_certificate = ca_response.ca_cert.public_bytes(serialization.Encoding.PEM).decode()
-    x509_ca_url = request.app.ca_client.ca_url
 
     node.activated = datetime.now(tz=timezone.utc)
     node.save()
@@ -216,5 +215,4 @@ async def enroll_node(
         trusted_keys=request.app.trusted_keys,
         x509_certificate=x509_certificate,
         x509_ca_certificate=x509_ca_certificate,
-        x509_ca_url=x509_ca_url,
     )


### PR DESCRIPTION
- Remove `ca_url` (renewal will be integrated in API)
- Update examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `NodeConfiguration` class with example values for fields: `name`, `mqtt_broker`, and `mqtt_topics` for improved clarity.
  
- **Bug Fixes**
	- Updated response status code for the `enroll_node` endpoint from 201 to 200, refining client expectations on enrollment success. 

- **Documentation**
	- Improved usability of the configuration by providing detailed examples for better understanding. 

- **Chores**
	- Removed unused field `x509_ca_url` from `NodeConfiguration`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->