### PR TITLE
Save issued certificates to database

### DIFF
--- a/nodeman/db_models.py
+++ b/nodeman/db_models.py
@@ -41,3 +41,24 @@ class TapirNodeEnrollment(Document):
 
     name = StringField(unique=True)
     key = DictField()
+
+
+class TapirCertificate(Document):
+    meta = {
+        "collection": "certificates",
+        "indexes": [
+            {"fields": ["name"]},
+            {"fields": ["issuer", "serial"], "unique": True},
+        ],
+    }
+
+    name = StringField()
+
+    issuer = StringField()
+    subject = StringField()
+    serial = StringField()
+
+    not_valid_before = DateTimeField()
+    not_valid_after = DateTimeField()
+
+    certificate = StringField()

--- a/nodeman/models.py
+++ b/nodeman/models.py
@@ -72,6 +72,7 @@ class NodeCertificate(BaseModel):
     x509_certificate: str = Field(title="X.509 Client Certificate Bundle")
     x509_ca_certificate: str = Field(title="X.509 CA Certificate Bundle")
     x509_certificate_serial_number: int | None = Field(default=None, exclude=True)
+    x509_certificate_not_valid_after: datetime
 
     @field_validator("x509_certificate", "x509_ca_certificate")
     @classmethod

--- a/nodeman/nodes.py
+++ b/nodeman/nodes.py
@@ -276,6 +276,7 @@ async def enroll_node(
         x509_certificate=node_certificate.x509_certificate,
         x509_ca_certificate=node_certificate.x509_ca_certificate,
         x509_certificate_serial_number=node_certificate.x509_certificate_serial_number,
+        x509_certificate_not_valid_after=node_certificate.x509_certificate_not_valid_after,
     )
 
 

--- a/nodeman/nodes.py
+++ b/nodeman/nodes.py
@@ -297,6 +297,7 @@ async def renew_node(
     node = find_node(name)
 
     if not node.activated:
+        logging.debug("Renewal attempt for non-activated node %s", name, extra={"nodename": name})
         raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Node not activated")
 
     span = trace.get_current_span()

--- a/nodeman/x509.py
+++ b/nodeman/x509.py
@@ -146,15 +146,7 @@ def process_csr_request(request: Request, csr: x509.CertificateSigningRequest, n
     x509_certificate_serial_number = x509_certificate.serial_number
     x509_not_valid_after_utc = x509_certificate.not_valid_after_utc.isoformat()
 
-    TapirCertificate(
-        name=name,
-        issuer=x509_certificate.issuer.rfc4514_string(),
-        subject=x509_certificate.subject.rfc4514_string(),
-        certificate=x509_certificate.public_bytes(serialization.Encoding.PEM).decode(),
-        serial=str(x509_certificate.serial_number),
-        not_valid_before=x509_certificate.not_valid_before_utc,
-        not_valid_after=x509_certificate.not_valid_after_utc,
-    ).save()
+    TapirCertificate.from_x509_certificate(name=name, x509_certificate=x509_certificate).save()
 
     logger.info(
         "Issued certificate for name=%s serial=%d not_valid_after=%s",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `TapirCertificate` class for storing certificate data.
	- Added `x509_certificate_not_valid_after` field to `NodeCertificate` for expiration dates.
	- Enhanced `enroll_node` function to include certificate expiration date in responses.

- **Bug Fixes**
	- Improved error handling in `renew_node` to prevent renewal of inactive nodes.

- **Documentation**
	- Updated method signatures to reflect new return values and added fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->