### PR TITLE
Allow Accept */*

### DIFF
--- a/nodeman/models.py
+++ b/nodeman/models.py
@@ -23,7 +23,7 @@ class PublicKeyFormat(StrEnum):
             return cls.JWK
         elif cls.PEM in accept:
             return cls.PEM
-        raise ValueError(f"Unsupported format. Acceptable formats: {[f.value for f in cls]}")
+        raise ValueError(f"Unsupported format. Acceptable formats: {[f.value for f in cls]} or */*")
 
 
 class NodeRequest(BaseModel):

--- a/nodeman/models.py
+++ b/nodeman/models.py
@@ -19,7 +19,7 @@ class PublicKeyFormat(StrEnum):
 
     @classmethod
     def from_accept(cls, accept: str | None) -> Self:
-        if accept is None or cls.JWK in accept or "application/json" in accept:
+        if accept is None or cls.JWK in accept or "application/json" in accept or "*/*" in accept:
             return cls.JWK
         elif cls.PEM in accept:
             return cls.PEM

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -160,6 +160,11 @@ def _test_enroll(data_key: JWK, x509_key: PrivateKey, requested_name: str | None
     res = JWK.from_json(response.text)
     assert res.kid == name
 
+    response = client.get(public_key_url, headers={"Accept": "*/*"})
+    assert response.status_code == status.HTTP_200_OK
+    res = JWK.from_json(response.text)
+    assert res.kid == name
+
     response = client.get(public_key_url, headers={"Accept": PublicKeyFormat.JWK})
     assert response.status_code == status.HTTP_200_OK
     res = JWK.from_json(response.text)


### PR DESCRIPTION
Some clients sends "Accept: */*" as default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced public key retrieval endpoint to support wildcard accept headers
  - Improved handling of different public key format requests

- **Tests**
  - Added test coverage for wildcard accept header scenarios in public key retrieval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->