### PR TITLE
Add endpoint to receive node certificate

### DIFF
--- a/nodeman/models.py
+++ b/nodeman/models.py
@@ -86,7 +86,7 @@ class NodeCertificate(BaseModel):
         return cls(
             x509_certificate=certificate.certificate,
             x509_ca_certificate=None,
-            x509_certificate_serial_number=certificate.serial,
+            x509_certificate_serial_number=str(certificate.serial),
             x509_certificate_not_valid_after=certificate.not_valid_after,
         )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -150,6 +150,14 @@ def _test_enroll(data_key: JWK, x509_key: PrivateKey, requested_name: str | None
     assert node_information["name"] == name
     assert response.headers.get("Cache-Control") is not None
 
+    ######################
+    # Get node certificate
+
+    response = client.get(f"{node_url}/certificate")
+    assert response.status_code == status.HTTP_200_OK
+    node_certificate = response.json()
+    print(json.dumps(node_certificate, indent=4))
+
     #####################
     # Get node public key
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -157,6 +157,12 @@ def _test_enroll(data_key: JWK, x509_key: PrivateKey, requested_name: str | None
     assert response.status_code == status.HTTP_200_OK
     node_certificate = response.json()
     print(json.dumps(node_certificate, indent=4))
+    assert node_certificate["x509_certificate"] == enrollment_response["x509_certificate"]
+    assert isinstance(node_certificate["x509_certificate_serial_number"], str)
+    assert node_certificate["x509_certificate_serial_number"] == enrollment_response["x509_certificate_serial_number"]
+    assert (
+        node_certificate["x509_certificate_not_valid_after"] == enrollment_response["x509_certificate_not_valid_after"]
+    )
 
     #####################
     # Get node public key


### PR DESCRIPTION
- Add endpoint to receive node certificate
- Also make all X.509 certificate serial numbers strings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added an endpoint to retrieve node certificates.
	- Enhanced `NodeCertificate` class with more flexible certificate handling, including optional fields and a method for instance creation from database models.

- **Bug Fixes**
	- Updated logging to correctly handle certificate serial number as a string.

- **Tests**
	- Added test case to verify node certificate retrieval functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->