### PR TITLE
Include nodeman URL in node bootstrap information

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,29 @@ nodeman-->>edge: Node configuration
 ```
 
 
+## Bootstrap Information
+
+
+```json
+{
+    "name": "clever-albattani.dev.dnstapir.se",
+    "key": {
+        "kty": "OKP",
+        "kid": "678e4054dc01bfd30ed2c22a",
+        "alg": "EdDSA",
+        "crv": "Ed25519",
+        "x": "bS8fqjtAhGfPZFRD0huGqejA46lZTPvhk5QunGYWPbc",
+        "d": "O1eqmHabqYSrnh7FyZTzzpYJRsvYFSofTssW_yA5nnk"
+    },
+    "nodeman_url": "http://localhost:8080/"
+}
+```
 
 ## Enrollment
 
 ### Request
 
-The enrollment request is a JWS signed with both the data key (algorithm depending on key algorithm) and the enrollment secret (algorithm `HS256`). JWS payload is a dictionary with the following properties:
+The enrollment request is a JWS signed with both the data and enrollment keys (algorithms depending on key algorithm). JWS payload is a dictionary with the following properties:
 
 - `timestamp`, A timestamp with the current time (ISO8601)
 - `x509_csr`, A string with a PEM-encoded X.509 Certificate Signing Request with _Common Name_ and _Subject Alternative Name_ set to the full node name.

--- a/nodeman.toml
+++ b/nodeman.toml
@@ -23,6 +23,7 @@ provisioner_private_key ="provisioner_private.json"
 #server = "http://localhost:8200"
 
 [nodes]
+nodeman_url = "http://localhost:8080"
 domain = "dev.dnstapir.se"
 trusted_jwks = "tests/trusted_jwks.json"
 mqtt_broker = "mqtts://localhost"
@@ -30,6 +31,11 @@ mqtt_broker = "mqtts://localhost"
 [nodes.mqtt_topics]
 tem = "configuration/tem"
 pop = "configuration/pop"
+
+[enrollment]
+kty = "OKP"
+crv = "Ed25519"
+alg = "EdDSA"
 
 #[otlp]
 #spans_endpoint = "http://localhost:4317"

--- a/nodeman/models.py
+++ b/nodeman/models.py
@@ -4,7 +4,7 @@ from enum import StrEnum
 from typing import Annotated, Self
 
 from cryptography.x509 import load_pem_x509_certificates
-from pydantic import BaseModel, Field, StringConstraints, field_validator
+from pydantic import AnyHttpUrl, BaseModel, Field, StringConstraints, field_validator
 from pydantic.types import AwareDatetime
 
 from .db_models import TapirCertificate, TapirNode
@@ -88,6 +88,7 @@ class NodeCollection(BaseModel):
 class NodeBootstrapInformation(BaseModel):
     name: str = Field(title="Node name")
     key: PrivateSymmetric | PrivateJwk = Field(title="Enrollment JWK")
+    nodeman_url: AnyHttpUrl | None = Field("Nodeman base URL")
 
 
 class NodeCertificate(BaseModel):

--- a/nodeman/nodes.py
+++ b/nodeman/nodes.py
@@ -184,7 +184,11 @@ async def create_node(
 
     logging.info("%s created node %s", username, node.name, extra={"username": username, "nodename": node.name})
 
-    return NodeBootstrapInformation(name=node.name, key=node_enrollment_key.export(as_dict=True, private_key=True))
+    return NodeBootstrapInformation(
+        name=node.name,
+        key=node_enrollment_key.export(as_dict=True, private_key=True),
+        nodeman_url=request.app.settings.nodes.nodeman_url,
+    )
 
 
 @router.get(

--- a/nodeman/settings.py
+++ b/nodeman/settings.py
@@ -51,6 +51,7 @@ class InternalCaSettings(BaseModel):
 
 
 class NodesSettings(BaseModel):
+    nodeman_url: AnyHttpUrl | None = Field(default=None)
     domain: str = Field(default="example.com")
     trusted_jwks: FilePath | None = Field(default=None)
     mqtt_broker: MqttUrl = Field(default="mqtt://localhost")

--- a/tests/test.toml
+++ b/tests/test.toml
@@ -4,6 +4,7 @@ legacy_nodes_directory = "tests/legacy"
 server =  "mongomock://localhost/nodes"
 
 [nodes]
+nodeman_url = "https://nodeman.test.tapir.se"
 domain = "test.dnstapir.se"
 trusted_jwks = "tests/trusted_jwks.json"
 mqtt_broker = "mqtts://localhost"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -81,9 +81,11 @@ def _test_enroll(data_key: JWK, x509_key: PrivateKey, requested_name: str | None
     assert response.status_code == status.HTTP_201_CREATED
     create_response = response.json()
     name = create_response["name"]
+    nodeman_url = create_response["nodeman_url"]
     logging.info("Got name=%s", name)
     if requested_name:
         assert name == requested_name
+    assert "https://" in nodeman_url
 
     node_url = urljoin(server, f"/api/v1/node/{name}")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added support for specifying a Nodeman service URL during node configuration
  - Enhanced key management for enrollment process

- **Documentation**
  - Updated README with bootstrap information and enrollment request details
  - Added configuration clarifications for node management

- **Configuration Updates**
  - Introduced new configuration options for nodes and enrollment settings
  - Updated test configurations to include Nodeman service URL

- **Improvements**
  - Refined enrollment key handling and signature mechanisms
  - Added URL validation for node creation process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->