### PR TITLE
Ensure we don't get any mismatched kid in data keys

### DIFF
--- a/nodeman/nodes.py
+++ b/nodeman/nodes.py
@@ -387,7 +387,12 @@ async def enroll_node(
                 "Invalid data signature from %s", name, extra={"nodename": name, "thumbprint": public_key.thumbprint()}
             )
             raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Invalid data signature") from exc
+
+        if public_key.key_id and public_key.key_id != name:
+            raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Invalid data name")
+
         node.public_key = public_key.export(as_dict=True, private_key=False)
+        node.public_key.pop("kid", None)
 
     # Verify X.509 CSR and issue certificate
     x509_csr = x509.load_pem_x509_csr(message.x509_csr.encode())

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -295,6 +295,13 @@ def test_enroll_p256_bad_named_node() -> None:
         _test_enroll(data_key=data_key, x509_key=x509_key, requested_name=requested_name)
 
 
+def test_enroll_p256_name_mismatch() -> None:
+    data_key = JWK.generate(kty="EC", crv="P-256", kid="xyzzy")
+    x509_key = ec.generate_private_key(ec.SECP256R1())
+    with pytest.raises(AssertionError):
+        _test_enroll(data_key=data_key, x509_key=x509_key)
+
+
 def test_enroll_bad_hmac_signature() -> None:
     client = get_test_client()
     server = ""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced node enrollment security by verifying that the provided identifier matches the expected node name. Enrollments with mismatched information now receive an access error.

- **Tests**
  - Added a scenario to ensure that the improved enrollment checks correctly block attempts with mismatched node details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->