### PR TITLE
Write server URL to data JWK

### DIFF
--- a/nodeman/client.py
+++ b/nodeman/client.py
@@ -20,7 +20,7 @@ from nodeman.x509 import generate_x509_csr
 
 PrivateKey = ec.EllipticCurvePrivateKey | rsa.RSAPublicKey | Ed25519PrivateKey | Ed448PrivateKey
 
-DEFAULT_SERVER = "http://127.0.0.1:8080"
+DEFAULT_SERVER = os.environ.get("NODEMAN_SERVER", "http://127.0.0.1:8080")
 
 
 def enroll(name: str, server: str, enrollment_key: JWK, data_key: JWK, x509_key: PrivateKey) -> NodeConfiguration:


### PR DESCRIPTION
Write server URL as `iss` to data JWK (and use it for renew)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved node management commands to automatically use a default server URL ("http://127.0.0.1:8080") when no custom server is provided.
- **Documentation**
  - Updated the server parameter’s help text to clarify its role as the "Nodeman server."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->