### PR TITLE
Add option to request specific certificate lifetime

### DIFF
--- a/nodeman.toml
+++ b/nodeman.toml
@@ -5,6 +5,9 @@ server =  "mongodb://localhost/nodeman"
 issuer_ca_certificate = "internal_ca_certificate.pem"
 issuer_ca_private_key = "internal_ca_private_key.pem"
 validity_days = 1
+min_validity_seconds = 10
+max_validity_seconds = 604800
+time_skew_seconds = 0
 
 #[step]
 #ca_url = "https://localhost:9000"

--- a/nodeman/client.py
+++ b/nodeman/client.py
@@ -8,7 +8,7 @@ from urllib.parse import urljoin
 
 import httpx
 from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.ed448 import Ed448PrivateKey
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from jwcrypto.jwk import JWK
@@ -16,16 +16,14 @@ from jwcrypto.jws import JWS
 
 from nodeman.jose import jwk_to_alg
 from nodeman.models import NodeBootstrapInformation, NodeCertificate, NodeConfiguration, NodeEnrollmentResult
-from nodeman.x509 import generate_x509_csr
-
-PrivateKey = ec.EllipticCurvePrivateKey | rsa.RSAPublicKey | Ed25519PrivateKey | Ed448PrivateKey
+from nodeman.x509 import PrivateKey, generate_x509_csr
 
 DEFAULT_SERVER = os.environ.get("NODEMAN_SERVER", "http://127.0.0.1:8080")
 
 
 def enroll(
     name: str, server: str, enrollment_key: JWK, data_key: JWK, x509_key: PrivateKey, lifetime: int | None
-) -> NodeConfiguration:
+) -> NodeEnrollmentResult:
     """Enroll new node"""
 
     enrollment_alg = enrollment_key.alg or jwk_to_alg(enrollment_key)

--- a/nodeman/internal_ca.py
+++ b/nodeman/internal_ca.py
@@ -136,15 +136,15 @@ class InternalCertificateAuthority(CertificateAuthorityClient):
                 self.logger.debug("Using requested certificate validity %s for %s", requested_validity, name)
             else:
                 self.logger.error(
-                    "Refusing requested certificate validity %s for %s (allowed: %s..%s)",
-                    requested_validity,
+                    "Refusing requested certificate validity %d for %s (allowed: %d..%d)",
+                    requested_validity.total_seconds(),
                     name,
-                    self.min_validity,
-                    self.max_validity,
+                    self.min_validity.total_seconds(),
+                    self.max_validity.total_seconds(),
                 )
                 raise CertificateRequestRefused(
-                    f"Requested validity {requested_validity} outside allowed range "
-                    f"[{self.min_validity}, {self.max_validity}]"
+                    f"Requested validity {requested_validity.total_seconds()} outside allowed range "
+                    f"[{self.min_validity.total_seconds()}, {self.max_validity.total_seconds()}]"
                 )
         else:
             validity = self.default_validity

--- a/nodeman/internal_ca.py
+++ b/nodeman/internal_ca.py
@@ -59,7 +59,7 @@ class InternalCertificateAuthority(CertificateAuthorityClient):
         self.issuer_ca_certificate = issuer_ca_certificate
         self.issuer_ca_private_key = issuer_ca_private_key
         self.root_ca_certificate = root_ca_certificate or issuer_ca_certificate
-        self.time_skew = timedelta(minutes=10) if time_skew is None else time_skew
+        self.time_skew = timedelta(minutes=0) if time_skew is None else time_skew
         self.default_validity = default_validity
         self.max_validity = max_validity or self.default_validity
         self.min_validity = min_validity or self.default_validity

--- a/nodeman/models.py
+++ b/nodeman/models.py
@@ -49,7 +49,12 @@ class NodeCreateRequest(BaseModel):
 class NodeRequest(BaseModel):
     timestamp: AwareDatetime = Field(title="Timestamp")
     x509_csr: str = Field(title="X.509 Client Certificate Bundle")
-    x509_lifetime: int | None = Field(title="Requested X.509 Client Certificate lifetime", default=None)
+    x509_lifetime: int | None = Field(
+        title="Requested X.509 Client Certificate lifetime",
+        description="Requested client certificate lifetime in seconds; must be > 0 and within CA policy limits.",
+        default=None,
+        gt=0,
+    )
 
     @field_validator("timestamp")
     @classmethod

--- a/nodeman/models.py
+++ b/nodeman/models.py
@@ -49,6 +49,7 @@ class NodeCreateRequest(BaseModel):
 class NodeRequest(BaseModel):
     timestamp: AwareDatetime = Field(title="Timestamp")
     x509_csr: str = Field(title="X.509 Client Certificate Bundle")
+    x509_lifetime: int | None = Field(title="Requested X.509 Client Certificate lifetime", default=None)
 
     @field_validator("timestamp")
     @classmethod

--- a/nodeman/nodes.py
+++ b/nodeman/nodes.py
@@ -97,7 +97,12 @@ def process_csr_request(
     """Verify CSR and issue certificate"""
 
     try:
-        validity = timedelta(seconds=lifetime) if lifetime else None
+        if lifetime is not None:
+            if lifetime <= 0:
+                raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Invalid certificate lifetime (must be > 0)")
+            validity = timedelta(seconds=lifetime)
+        else:
+            validity = None
         ca_response = request.app.ca_client.sign_csr(csr, name, validity)
     except CertificateRequestRefused as exc:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Certificate request refused") from exc

--- a/nodeman/nodes.py
+++ b/nodeman/nodes.py
@@ -2,7 +2,7 @@ import ipaddress
 import json
 import logging
 from contextlib import suppress
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated
 
@@ -35,6 +35,7 @@ from .models import (
     PublicKeyFormat,
     RenewalRequest,
 )
+from .x509 import CertificateRequestRefused
 
 logger = logging.getLogger(__name__)
 
@@ -87,11 +88,19 @@ def create_node_configuration(name: str, request: Request) -> NodeConfiguration:
     )
 
 
-def process_csr_request(request: Request, csr: x509.CertificateSigningRequest, name: str) -> NodeCertificate:
+def process_csr_request(
+    request: Request,
+    csr: x509.CertificateSigningRequest,
+    name: str,
+    lifetime: int | None = None,
+) -> NodeCertificate:
     """Verify CSR and issue certificate"""
 
     try:
-        ca_response = request.app.ca_client.sign_csr(csr, name)
+        validity = timedelta(seconds=lifetime) if lifetime else None
+        ca_response = request.app.ca_client.sign_csr(csr, name, validity)
+    except CertificateRequestRefused as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Certificate request refused") from exc
     except Exception as exc:
         logger.error("Failed to process CSR for %s: %s", name, str(exc), exc_info=exc)
         raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Error issuing certificate") from exc
@@ -455,7 +464,12 @@ async def enroll_node(
             x509_csr = x509.load_pem_x509_csr(message.x509_csr.encode())
         except ValueError as exc:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Invalid CSR") from exc
-        node_certificate = process_csr_request(csr=x509_csr, name=name, request=request)
+        node_certificate = process_csr_request(
+            csr=x509_csr,
+            name=name,
+            lifetime=message.x509_lifetime,
+            request=request,
+        )
 
     node.activated = datetime.now(tz=UTC)
     node.save()
@@ -525,7 +539,12 @@ async def renew_node(
             x509_csr = x509.load_pem_x509_csr(message.x509_csr.encode())
         except ValueError as exc:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Invalid CSR") from exc
-        res = process_csr_request(csr=x509_csr, name=name, request=request)
+        res = process_csr_request(
+            csr=x509_csr,
+            name=name,
+            lifetime=message.x509_lifetime,
+            request=request,
+        )
 
     nodes_renewed.add(1)
 

--- a/nodeman/server.py
+++ b/nodeman/server.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 from contextlib import asynccontextmanager
+from datetime import timedelta
 
 import mongoengine
 import uvicorn
@@ -92,7 +93,9 @@ class NodemanServer(FastAPI):
             issuer_ca_certificate_file=settings.issuer_ca_certificate,
             issuer_ca_private_key_file=settings.issuer_ca_private_key,
             root_ca_certificate_file=settings.root_ca_certificate,
-            validity_days=settings.validity_days,
+            default_validity=timedelta(days=settings.validity_days),
+            min_validity=timedelta(seconds=settings.min_validity_seconds) if settings.min_validity_seconds else None,
+            max_validity=timedelta(seconds=settings.max_validity_seconds) if settings.max_validity_seconds else None,
         )
         self.logger.info("Configured Internal CA (%s)", res.ca_fingerprint)
         return res

--- a/nodeman/server.py
+++ b/nodeman/server.py
@@ -96,6 +96,7 @@ class NodemanServer(FastAPI):
             default_validity=timedelta(days=settings.validity_days),
             min_validity=timedelta(seconds=settings.min_validity_seconds) if settings.min_validity_seconds else None,
             max_validity=timedelta(seconds=settings.max_validity_seconds) if settings.max_validity_seconds else None,
+            time_skew=timedelta(seconds=settings.time_skew_seconds),
         )
         self.logger.info("Configured Internal CA (%s)", res.ca_fingerprint)
         return res

--- a/nodeman/settings.py
+++ b/nodeman/settings.py
@@ -70,9 +70,9 @@ class InternalCaSettings(BaseModel):
     issuer_ca_certificate: FilePath
     issuer_ca_private_key: FilePath
     root_ca_certificate: FilePath | None = None
-    validity_days: int = Field(default=90, gt=0)
-    min_validity_seconds: int | None = Field(default=None, gt=0)
-    max_validity_seconds: int | None = Field(default=None, gt=0)
+    validity_days: int = Field(default=90, ge=0)
+    min_validity_seconds: int | None = Field(default=None, ge=0)
+    max_validity_seconds: int | None = Field(default=None, ge=0)
     time_skew_seconds: int = Field(default=0, ge=0)
 
     @property

--- a/nodeman/settings.py
+++ b/nodeman/settings.py
@@ -71,8 +71,9 @@ class InternalCaSettings(BaseModel):
     issuer_ca_private_key: FilePath
     root_ca_certificate: FilePath | None = None
     validity_days: int = Field(default=90, gt=0)
-    min_validity_seconds: int | None = Field(default=None, ge=0)
-    max_validity_seconds: int | None = Field(default=None, ge=0)
+    min_validity_seconds: int | None = Field(default=None, gt=0)
+    max_validity_seconds: int | None = Field(default=None, gt=0)
+    time_skew_seconds: int = Field(default=0, ge=0)
 
     # within class InternalCaSettings
     @model_validator(mode="after")

--- a/nodeman/settings.py
+++ b/nodeman/settings.py
@@ -75,15 +75,26 @@ class InternalCaSettings(BaseModel):
     max_validity_seconds: int | None = Field(default=None, gt=0)
     time_skew_seconds: int = Field(default=0, ge=0)
 
+    @property
+    def validity_seconds(self) -> int:
+        return self.validity_days * 86400
+
     # within class InternalCaSettings
     @model_validator(mode="after")
     def _validate_validity_bounds(self) -> Self:
         if (
-            self.min_validity_seconds
-            and self.max_validity_seconds
+            self.min_validity_seconds is not None
+            and self.max_validity_seconds is not None
             and self.min_validity_seconds > self.max_validity_seconds
         ):
             raise ValueError("min_validity_seconds must be <= max_validity_seconds")
+
+        if self.min_validity_seconds is not None and self.validity_seconds < self.min_validity_seconds:
+            raise ValueError("validity shorter than min validity")
+
+        if self.max_validity_seconds is not None and self.validity_seconds > self.max_validity_seconds:
+            raise ValueError("validity larger than max validity")
+
         return self
 
 

--- a/nodeman/settings.py
+++ b/nodeman/settings.py
@@ -70,9 +70,20 @@ class InternalCaSettings(BaseModel):
     issuer_ca_certificate: FilePath
     issuer_ca_private_key: FilePath
     root_ca_certificate: FilePath | None = None
-    validity_days: int = Field(default=90)
-    min_validity_seconds: int | None = Field(default=None)
-    max_validity_seconds: int | None = Field(default=None)
+    validity_days: int = Field(default=90, gt=0)
+    min_validity_seconds: int | None = Field(default=None, ge=0)
+    max_validity_seconds: int | None = Field(default=None, ge=0)
+
+    # within class InternalCaSettings
+    @model_validator(mode="after")
+    def _validate_validity_bounds(self) -> Self:
+        if (
+            self.min_validity_seconds
+            and self.max_validity_seconds
+            and self.min_validity_seconds > self.max_validity_seconds
+        ):
+            raise ValueError("min_validity_seconds must be <= max_validity_seconds")
+        return self
 
 
 class NodesSettings(BaseModel):

--- a/nodeman/settings.py
+++ b/nodeman/settings.py
@@ -71,6 +71,8 @@ class InternalCaSettings(BaseModel):
     issuer_ca_private_key: FilePath
     root_ca_certificate: FilePath | None = None
     validity_days: int = Field(default=90)
+    min_validity_seconds: int | None = Field(default=None)
+    max_validity_seconds: int | None = Field(default=None)
 
 
 class NodesSettings(BaseModel):

--- a/nodeman/step.py
+++ b/nodeman/step.py
@@ -46,7 +46,7 @@ class StepClient(CertificateAuthorityClient):
         self.logger.debug("Processing CSR from %s", name)
 
         if requested_validity is not None:
-            self.logger.warning("Ignoring requested certificate validity")
+            self.logger.warning("Ignoring requested certificate validity (%s)", requested_validity)
 
         verify_x509_csr_signature(csr=csr, name=name)
         verify_x509_csr_data(csr=csr, name=name)

--- a/nodeman/step.py
+++ b/nodeman/step.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import time
 import uuid
+from datetime import timedelta
 from urllib.parse import urljoin
 
 import httpx
@@ -34,10 +35,18 @@ class StepClient(CertificateAuthorityClient):
         self.token_ttl = 300
         self.verify = self.ca_bundle_filename if ca_server_verify else False
 
-    def sign_csr(self, csr: x509.CertificateSigningRequest, name: str) -> CertificateInformation:
+    def sign_csr(
+        self,
+        csr: x509.CertificateSigningRequest,
+        name: str,
+        requested_validity: timedelta | None = None,
+    ) -> CertificateInformation:
         """Sign CSR with Step CA"""
 
         self.logger.debug("Processing CSR from %s", name)
+
+        if requested_validity is not None:
+            self.logger.warning("Ignoring requested certificate validity")
 
         verify_x509_csr_signature(csr=csr, name=name)
         verify_x509_csr_data(csr=csr, name=name)

--- a/nodeman/x509.py
+++ b/nodeman/x509.py
@@ -26,9 +26,18 @@ class CertificateInformation:
     ca_cert: x509.Certificate
 
 
+class CertificateRequestRefused(ValueError):
+    pass
+
+
 class CertificateAuthorityClient(ABC):
     @abstractmethod
-    def sign_csr(self, csr: x509.CertificateSigningRequest, name: str) -> CertificateInformation:
+    def sign_csr(
+        self,
+        csr: x509.CertificateSigningRequest,
+        name: str,
+        requested_validity: timedelta | None = None,
+    ) -> CertificateInformation:
         pass
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -41,11 +41,13 @@ def get_ca_client() -> CertificateAuthorityClient:
     ca_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Internal Test CA")])
     ca_private_key = ec.generate_private_key(ec.SECP256R1())
     ca_certificate = generate_ca_certificate(ca_name, ca_private_key)
-    validity = timedelta(minutes=10)
     return InternalCertificateAuthority(
         issuer_ca_certificate=ca_certificate,
         issuer_ca_private_key=ca_private_key,
-        validity=validity,
+        default_validity=timedelta(seconds=60),
+        min_validity=timedelta(seconds=10),
+        max_validity=timedelta(seconds=3600),
+        time_skew=timedelta(seconds=0),
     )
 
 
@@ -216,8 +218,8 @@ def _test_enroll(data_key: JWK, x509_key: PrivateKey, requested_name: str | None
     response = client.post(f"{node_url}/renew", json=renew_request)
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    ###################
-    # Renew certificate
+    #####################################################
+    # Renew certificate with default certificate lifetime
 
     x509_csr = generate_x509_csr(key=x509_key, name=name).public_bytes(serialization.Encoding.PEM).decode()
     payload = {
@@ -237,6 +239,54 @@ def _test_enroll(data_key: JWK, x509_key: PrivateKey, requested_name: str | None
     certs = x509.load_pem_x509_certificates(renew_response["x509_certificate"].encode())
     certificate_serial_number_2 = certs[0].serial_number
     assert certificate_serial_number_1 != certificate_serial_number_2
+
+    ttl = certs[0].not_valid_after_utc - certs[0].not_valid_before_utc
+    assert ttl.total_seconds() == client.app.ca_client.default_validity.total_seconds()
+
+    ###################################################
+    # Renew certificate with short certificate lifetime
+
+    x509_lifetime = 60
+    x509_csr = generate_x509_csr(key=x509_key, name=name).public_bytes(serialization.Encoding.PEM).decode()
+    payload = {
+        "timestamp": datetime.now(tz=UTC).isoformat(),
+        "x509_csr": x509_csr,
+        "x509_lifetime": x509_lifetime,
+    }
+
+    jws = JWS(payload=json.dumps(payload))
+    jws.add_signature(key=data_key, alg=data_alg, protected={"alg": data_alg})
+    renew_request = json.loads(jws.serialize())
+
+    response = client.post(f"{node_url}/renew", json=renew_request)
+    assert response.status_code == status.HTTP_200_OK
+
+    renew_response = response.json()
+    print(json.dumps(renew_response, indent=4))
+    certs = x509.load_pem_x509_certificates(renew_response["x509_certificate"].encode())
+    certificate_serial_number_2 = certs[0].serial_number
+    assert certificate_serial_number_1 != certificate_serial_number_2
+
+    ttl = certs[0].not_valid_after_utc - certs[0].not_valid_before_utc
+    assert ttl.total_seconds() == x509_lifetime
+
+    #########################################
+    # Renew certificate with invalid lifetime
+
+    x509_lifetime = 7200
+    x509_csr = generate_x509_csr(key=x509_key, name=name).public_bytes(serialization.Encoding.PEM).decode()
+    payload = {
+        "timestamp": datetime.now(tz=UTC).isoformat(),
+        "x509_csr": x509_csr,
+        "x509_lifetime": x509_lifetime,
+    }
+
+    jws = JWS(payload=json.dumps(payload))
+    jws.add_signature(key=data_key, alg=data_alg, protected={"alg": data_alg})
+    renew_request = json.loads(jws.serialize())
+
+    response = client.post(f"{node_url}/renew", json=renew_request)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     ###########
     # Clean up

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -246,7 +246,7 @@ def _test_enroll(data_key: JWK, x509_key: PrivateKey, requested_name: str | None
     ###################################################
     # Renew certificate with short certificate lifetime
 
-    x509_lifetime = 60
+    x509_lifetime = 42
     x509_csr = generate_x509_csr(key=x509_key, name=name).public_bytes(serialization.Encoding.PEM).decode()
     payload = {
         "timestamp": datetime.now(tz=UTC).isoformat(),

--- a/tests/test_internal_ca.py
+++ b/tests/test_internal_ca.py
@@ -40,7 +40,9 @@ def _test_internal_ca(ca_private_key: PrivateKey, verify: bool = True) -> None:
 
     validity = timedelta(minutes=10)
     ca_client = InternalCertificateAuthority(
-        issuer_ca_certificate=ca_certificate, issuer_ca_private_key=ca_private_key, validity=validity
+        issuer_ca_certificate=ca_certificate,
+        issuer_ca_private_key=ca_private_key,
+        default_validity=validity,
     )
 
     _ = ca_client.ca_fingerprint
@@ -92,7 +94,7 @@ def test_internal_sub_ca() -> None:
         issuer_ca_certificate=issuer_ca_certificate,
         issuer_ca_private_key=issuer_ca_private_key,
         root_ca_certificate=root_ca_certificate,
-        validity=validity,
+        default_validity=validity,
     )
 
     name = "hostname.example.com"
@@ -125,6 +127,7 @@ def test_internal_ca_file() -> None:
     _ = InternalCertificateAuthority.load(
         issuer_ca_certificate_file=ca_certificate_file,
         issuer_ca_private_key_file=ca_private_key_file,
+        default_validity=timedelta(seconds=0),
     )
 
     os.unlink(ca_certificate_file)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Per-request TLS certificate lifetime: clients may include x509_lifetime (seconds) to request a specific certificate TTL.
  - Configurable CA policy: server supports default lifetime, optional min/max bounds and time-skew settings; client/CLI expose --tls-cert-lifetime.

- **Bug Fixes**
  - Invalid lifetime requests are rejected with a 400 "Certificate request refused".

- **Refactor**
  - Certificate validity handling consolidated and validated across client, server, and CA.

- **Tests**
  - Coverage expanded to verify default, valid, and invalid lifetime flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->