### PR TITLE
Include entire model in node create response

### DIFF
--- a/nodeman/client.py
+++ b/nodeman/client.py
@@ -172,7 +172,7 @@ def command_create(args: argparse.Namespace) -> NodeBootstrapInformation:
     logging.debug("Response: %s", json.dumps(create_response, indent=4))
     logging.info("Created node with name=%s", name)
 
-    return NodeBootstrapInformation(name=name, key=create_response["key"])
+    return NodeBootstrapInformation.model_validate(create_response)
 
 
 def command_delete(args: argparse.Namespace) -> None:


### PR DESCRIPTION
`nodeman_url` was missing from node create response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of node creation responses using model-based validation for greater data consistency and robustness.
  * Enhances reliability during initial node setup and provides clearer validation of server responses.
  * No changes to user workflows or interfaces; behavior remains the same under normal conditions.
  * Lays groundwork for better resilience to API variations, reducing potential edge-case failures without altering existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->