### PR TITLE
Allow node lookup by data key thumbprint

### DIFF
--- a/nodeman/nodes.py
+++ b/nodeman/nodes.py
@@ -348,6 +348,12 @@ def get_all_nodes(
     else:
         logging.info("%s queried for all nodes", username, extra={"username": username})
     if thumbprint:
+        logging.info(
+            "%s queried for nodes with thumbprint %s",
+            username,
+            thumbprint,
+            extra={"username": username, "thumbprint": thumbprint},
+        )
         query &= Q(thumbprint=thumbprint)
     return NodeCollection(nodes=[NodeInformation.from_db_model(node) for node in TapirNode.objects(query)])
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -641,6 +641,14 @@ def test_thumbprint_filter() -> None:
     assert len(nodes.nodes) == 1
     assert nodes.nodes[0].name == name
 
+    # Find public key by unknown thumbprint
+    unknown_thumbprint = JWK.generate(kty="OKP", crv="Ed25519").thumbprint()
+    nodes_url = urljoin(server, f"/api/v1/nodes?thumbprint={unknown_thumbprint}")
+    response = client.get(nodes_url, headers={"Accept": "application/json"})
+    assert response.status_code == status.HTTP_200_OK
+    nodes = NodeCollection.model_validate(response.json())
+    assert len(nodes.nodes) == 0
+
 
 def test_backend_authentication() -> None:
     client = get_test_client()


### PR DESCRIPTION
Closing #81 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support to filter node listings by public key thumbprint via query parameter.

* **Refactor**
  * Node list API responses now omit fields with null values for cleaner payloads.

* **Tests**
  * Added end-to-end test covering thumbprint-based filtering.
  * Updated admin node listing test to expect absence of the activated field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->